### PR TITLE
Package ppx_optcomp.v0.17.0

### DIFF
--- a/packages/ppx_optcomp/ppx_optcomp.v0.17.0/opam
+++ b/packages/ppx_optcomp/ppx_optcomp.v0.17.0/opam
@@ -1,6 +1,4 @@
 opam-version: "2.0"
-name: "ppx_optcomp"
-version: "v0.17.0"
 synopsis: "Optional compilation for OCaml"
 description: "Part of the Jane Street's PPX rewriters collection."
 maintainer: "Jane Street developers"
@@ -12,8 +10,8 @@ doc:
 bug-reports: "https://github.com/janestreet/ppx_optcomp/issues"
 depends: [
   "ocaml" {>= "5.1.0"}
-  "base" {>= "v0.17" & < "v0.18"}
-  "stdio" {>= "v0.17" & < "v0.18"}
+  "base"
+  "stdio"
   "dune" {>= "3.11.0"}
   "ppxlib" {>= "0.28.0"}
 ]
@@ -22,7 +20,9 @@ build: ["dune" "build" "-p" name "-j" jobs]
 dev-repo: "git+https://github.com/janestreet/ppx_optcomp.git"
 url {
   src:
-    "https://github.com/patricoferris/ppx_optcomp/archive/refs/tags/v0.17.0.tar.gz"
-  checksum:
-    "sha512=be874b4a1082c256c856838c55db19de1854b8a330a572c699ce537acef0ded8994ece2170b41c4e2760a4b0e19e4a9c6df46ea7e7e6c3e412f150deb198bbc4"
+    "https://github.com/patricoferris/ppx_optcomp/archive/heads/5.2-ast-bump.tar.gz"
+  checksum: [
+    "md5=21caacd4757d34eb8d47b90e1f694485"
+    "sha512=625edaeed84fcdbbb31ebcbcbf14e86a558dea043e3b05c11d7b0b5a9608ee802d33104f04f0d06f765242aec1384fb286c7bcb28a4f1dbb7e18b93299196fe8"
+  ]
 }


### PR DESCRIPTION
### `ppx_optcomp.v0.17.0`
Optional compilation for OCaml
Part of the Jane Street's PPX rewriters collection.



---
* Homepage: https://github.com/janestreet/ppx_optcomp
* Source repo: git+https://github.com/janestreet/ppx_optcomp.git
* Bug tracker: https://github.com/janestreet/ppx_optcomp/issues

---
:camel: Pull-request generated by opam-publish v2.3.1