### PR TITLE
Package ppx_let.v0.17.0

### DIFF
--- a/packages/ppx_let/ppx_let.v0.17.0/opam
+++ b/packages/ppx_let/ppx_let.v0.17.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "Monadic let-bindings"
+description: "Part of the Jane Street's PPX rewriters collection."
+maintainer: "Jane Street developers"
+authors: "Jane Street Group, LLC"
+license: "MIT"
+homepage: "https://github.com/janestreet/ppx_let"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_let/index.html"
+bug-reports: "https://github.com/janestreet/ppx_let/issues"
+depends: [
+  "ocaml" {>= "5.1.0"}
+  "base"
+  "ppx_here"
+  "dune" {>= "3.11.0"}
+  "ppxlib" {>= "0.28.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/janestreet/ppx_let.git"
+url {
+  src:
+    "https://github.com/patricoferris/ppx_let/archive/heads/5.2-ast-bump.tar.gz"
+  checksum: [
+    "md5=9757a58cc55d93090c1fa95f77b28e94"
+    "sha512=160c9976556ec9e03668b9e1ca5df765481b58fbcb22a1fcb17a688b623d59ecd2e432470eb9c9b09e63474d8cb73d47675bb47fc642f72d1ce2f81a5631d0b9"
+  ]
+}


### PR DESCRIPTION
### `ppx_let.v0.17.0`
Monadic let-bindings
Part of the Jane Street's PPX rewriters collection.



---
* Homepage: https://github.com/janestreet/ppx_let
* Source repo: git+https://github.com/janestreet/ppx_let.git
* Bug tracker: https://github.com/janestreet/ppx_let/issues

---
:camel: Pull-request generated by opam-publish v2.3.1