### PR TITLE
Package ppx_globalize.v0.17.0

### DIFF
--- a/packages/ppx_globalize/ppx_globalize.v0.17.0/opam
+++ b/packages/ppx_globalize/ppx_globalize.v0.17.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis:
+  "A ppx rewriter that generates functions to copy local values to the global heap"
+description: "Part of the Jane Street's PPX rewriters collection."
+maintainer: "Jane Street developers"
+authors: "Jane Street Group, LLC"
+license: "MIT"
+homepage: "https://github.com/janestreet/ppx_globalize"
+doc:
+  "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_globalize/index.html"
+bug-reports: "https://github.com/janestreet/ppx_globalize/issues"
+depends: [
+  "ocaml" {>= "5.1.0"}
+  "base"
+  "ppxlib_jane"
+  "dune" {>= "3.11.0"}
+  "ppxlib" {>= "0.28.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/janestreet/ppx_globalize.git"
+url {
+  src:
+    "https://github.com/patricoferris/ppx_globalize/archive/heads/5.2-ast-bump.tar.gz"
+  checksum: [
+    "md5=36de725c943576d81ed55b4fd18a3e37"
+    "sha512=080ecd1474514db131bfd1e6519d16157d79ecb673bab1374b28b54bc012a60700ad116c32c7cce62fac123184eaeafeedf6bf7c41ebd4d4e4cfa53c1d03d871"
+  ]
+}


### PR DESCRIPTION
### `ppx_globalize.v0.17.0`
A ppx rewriter that generates functions to copy local values to the global heap
Part of the Jane Street's PPX rewriters collection.



---
* Homepage: https://github.com/janestreet/ppx_globalize
* Source repo: git+https://github.com/janestreet/ppx_globalize.git
* Bug tracker: https://github.com/janestreet/ppx_globalize/issues

---
:camel: Pull-request generated by opam-publish v2.3.1