### PR TITLE
2 packages from patricoferris/ppxlib at 0.35.0

### DIFF
--- a/packages/ppxlib-bench/ppxlib-bench.0.35.0/opam
+++ b/packages/ppxlib-bench/ppxlib-bench.0.35.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Run ppxlib benchmarks"
+description: """\
+Third-party code in benchmarks depends on later versions of the ocaml
+than ppxlib itself. Also the benchmark runner has dependencies that ppxlib doesn't
+have."""
+maintainer: "opensource@janestreet.com"
+authors: "Jane Street Group, LLC <opensource@janestreet.com>"
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ppxlib"
+doc: "https://ocaml-ppx.github.io/ppxlib/"
+bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.04.1"}
+  "ppxlib" {= version}
+  "base"
+  "yojson"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"
+url {
+  src:
+    "https://github.com/patricoferris/ppxlib/archive/heads/5.2-bump.tar.gz"
+  checksum: [
+    "md5=94dbd7eaba9cdc0dc671cff3eac5b09a"
+    "sha512=ba536ecac94308b4ca9b1a6b2d6258c47da092d73bbd3135e4e9aa2346ec4660703d1eefa9e64c89e202f1d94765d94c66d26c7a5027f6cb74c39a35b9e138dc"
+  ]
+}

--- a/packages/ppxlib/ppxlib.0.35.0/opam
+++ b/packages/ppxlib/ppxlib.0.35.0/opam
@@ -1,0 +1,61 @@
+opam-version: "2.0"
+synopsis: "Standard infrastructure for ppx rewriters"
+description: """\
+Ppxlib is the standard infrastructure for ppx rewriters
+and other programs that manipulate the in-memory representation of
+OCaml programs, a.k.a the "Parsetree".
+
+It also comes bundled with two ppx rewriters that are commonly used to
+write tools that manipulate and/or generate Parsetree values;
+`ppxlib.metaquot` which allows to construct Parsetree values using the
+OCaml syntax directly and `ppxlib.traverse` which provides various
+ways of automatically traversing values of a given type, in particular
+allowing to inject a complex structured value into generated code."""
+maintainer: "opensource@janestreet.com"
+authors: "Jane Street Group, LLC <opensource@janestreet.com>"
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ppxlib"
+doc: "https://ocaml-ppx.github.io/ppxlib/"
+bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.04.1" & < "5.4.0"}
+  "ocaml-compiler-libs" {>= "v0.11.0"}
+  "ppx_derivers" {>= "1.0"}
+  "sexplib0" {>= "v0.12"}
+  "sexplib0" {with-test & >= "v0.15"}
+  "stdlib-shims"
+  "ocamlfind" {with-test}
+  "re" {with-test & >= "1.9.0"}
+  "cinaps" {with-test & >= "v0.12.1"}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "ocaml-migrate-parsetree" {< "2.0.0"}
+  "ocaml-base-compiler" {= "5.1.0~alpha1"}
+  "ocaml-variants" {= "5.1.0~alpha1+options"}
+  "base-effects"
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"
+url {
+  src:
+    "https://github.com/patricoferris/ppxlib/archive/heads/5.2-bump.tar.gz"
+  checksum: [
+    "md5=94dbd7eaba9cdc0dc671cff3eac5b09a"
+    "sha512=ba536ecac94308b4ca9b1a6b2d6258c47da092d73bbd3135e4e9aa2346ec4660703d1eefa9e64c89e202f1d94765d94c66d26c7a5027f6cb74c39a35b9e138dc"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `ppxlib.0.35.0`: Standard infrastructure for ppx rewriters
- `ppxlib-bench.0.35.0`: Run ppxlib benchmarks



---
* Homepage: https://github.com/ocaml-ppx/ppxlib
* Source repo: git+https://github.com/ocaml-ppx/ppxlib.git
* Bug tracker: https://github.com/ocaml-ppx/ppxlib/issues

---
:camel: Pull-request generated by opam-publish v2.3.1