### PR TITLE
2 packages from patricoferris/ppxlib at 0.35.0

### DIFF
--- a/packages/ppxlib-bench/ppxlib-bench.0.35.0/opam
+++ b/packages/ppxlib-bench/ppxlib-bench.0.35.0/opam
@@ -37,7 +37,7 @@ url {
   src:
     "https://github.com/patricoferris/ppxlib/archive/heads/5.2-bump.tar.gz"
   checksum: [
-    "md5=94dbd7eaba9cdc0dc671cff3eac5b09a"
-    "sha512=ba536ecac94308b4ca9b1a6b2d6258c47da092d73bbd3135e4e9aa2346ec4660703d1eefa9e64c89e202f1d94765d94c66d26c7a5027f6cb74c39a35b9e138dc"
+    "md5=34f402ccb323eb2a10cced5a75ff57f8"
+    "sha512=f75a270336768e1ecc13d3be1d3b415d81b8a0772ee7ba8741b599d55c49d7e43e454cbf72299c71086a27af467055da7be5fd60392dd49c95680381ce5ffb86"
   ]
 }

--- a/packages/ppxlib/ppxlib.0.35.0/opam
+++ b/packages/ppxlib/ppxlib.0.35.0/opam
@@ -55,7 +55,7 @@ url {
   src:
     "https://github.com/patricoferris/ppxlib/archive/heads/5.2-bump.tar.gz"
   checksum: [
-    "md5=94dbd7eaba9cdc0dc671cff3eac5b09a"
-    "sha512=ba536ecac94308b4ca9b1a6b2d6258c47da092d73bbd3135e4e9aa2346ec4660703d1eefa9e64c89e202f1d94765d94c66d26c7a5027f6cb74c39a35b9e138dc"
+    "md5=34f402ccb323eb2a10cced5a75ff57f8"
+    "sha512=f75a270336768e1ecc13d3be1d3b415d81b8a0772ee7ba8741b599d55c49d7e43e454cbf72299c71086a27af467055da7be5fd60392dd49c95680381ce5ffb86"
   ]
 }


### PR DESCRIPTION
This pull-request concerns:
- `ppxlib.0.35.0`: Standard infrastructure for ppx rewriters
- `ppxlib-bench.0.35.0`: Run ppxlib benchmarks



---
* Homepage: https://github.com/ocaml-ppx/ppxlib
* Source repo: git+https://github.com/ocaml-ppx/ppxlib.git
* Bug tracker: https://github.com/ocaml-ppx/ppxlib/issues

---
:camel: Pull-request generated by opam-publish v2.3.1