### PR TITLE
3 packages from patricoferris/ppxlib at 0.35.0

### DIFF
--- a/packages/ppxlib-tools/ppxlib-tools.0.35.0/opam
+++ b/packages/ppxlib-tools/ppxlib-tools.0.35.0/opam
@@ -1,9 +1,10 @@
 opam-version: "2.0"
-synopsis: "Run ppxlib benchmarks"
+synopsis: "Tools for PPX users and authors"
 description: """\
-Third-party code in benchmarks depends on later versions of the ocaml
-than ppxlib itself. Also the benchmark runner has dependencies that ppxlib doesn't
-have."""
+Set of helper tools for PPX users and authors.
+
+ppxlib-pp-ast: Command line tool to pretty print OCaml ASTs in a human readable
+format."""
 maintainer: "opensource@janestreet.com"
 authors: "Jane Street Group, LLC <opensource@janestreet.com>"
 license: "MIT"
@@ -12,10 +13,9 @@ doc: "https://ocaml-ppx.github.io/ppxlib/"
 bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
 depends: [
   "dune" {>= "2.8"}
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.08.0"}
   "ppxlib" {= version}
-  "base"
-  "yojson"
+  "cmdliner" {>= "1.3.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/ppxlib/ppxlib.0.35.0/opam
+++ b/packages/ppxlib/ppxlib.0.35.0/opam
@@ -18,7 +18,7 @@ homepage: "https://github.com/ocaml-ppx/ppxlib"
 doc: "https://ocaml-ppx.github.io/ppxlib/"
 bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
 depends: [
-  "dune" {>= "2.7"}
+  "dune" {>= "2.8"}
   "ocaml" {>= "4.04.1" & < "5.4.0"}
   "ocaml-compiler-libs" {>= "v0.11.0"}
   "ppx_derivers" {>= "1.0"}
@@ -28,13 +28,13 @@ depends: [
   "ocamlfind" {with-test}
   "re" {with-test & >= "1.9.0"}
   "cinaps" {with-test & >= "v0.12.1"}
+  "ocamlformat" {with-dev-setup & = "0.26.2"}
   "odoc" {with-doc}
 ]
 conflicts: [
   "ocaml-migrate-parsetree" {< "2.0.0"}
   "ocaml-base-compiler" {= "5.1.0~alpha1"}
   "ocaml-variants" {= "5.1.0~alpha1+options"}
-  "base-effects"
 ]
 build: [
   ["dune" "subst"] {dev}
@@ -55,7 +55,7 @@ url {
   src:
     "https://github.com/patricoferris/ppxlib/archive/heads/5.2-bump.tar.gz"
   checksum: [
-    "md5=55efa0e6e4a1a8f403ffc266374b4188"
-    "sha512=5730dca749c6c19488368789265a90dc57f568da9131dee6eec83ad75de69d90a7d0f1f1464ad589a21ae05bd72795d8ef7b81cca5b05a7548be368189e734e4"
+    "md5=370522064962bf2f8782273f7ee9be35"
+    "sha512=420a01494005ef6ad16c82dbb0dbc9a0040ca23879a99178c5936e3d65051a2abaaa47b5c690877943d7a6332e1bc014b7302a1ef8bbb8e9d84b1232994edf58"
   ]
 }


### PR DESCRIPTION
This pull-request concerns:
- `ppxlib.0.35.0`: Standard infrastructure for ppx rewriters
- `ppxlib-bench.0.35.0`: Run ppxlib benchmarks
- `ppxlib-tools.0.35.0`: Tools for PPX users and authors



---
* Homepage: https://github.com/ocaml-ppx/ppxlib
* Source repo: git+https://github.com/ocaml-ppx/ppxlib.git
* Bug tracker: https://github.com/ocaml-ppx/ppxlib/issues

---
:camel: Pull-request generated by opam-publish v2.4.0