### PR TITLE
Package ppx_globalize.v0.17.0

### DIFF
--- a/packages/ppx_globalize/ppx_globalize.v0.17.0/opam
+++ b/packages/ppx_globalize/ppx_globalize.v0.17.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis:
+  "A ppx rewriter that generates functions to copy local values to the global heap"
+description: "Part of the Jane Street's PPX rewriters collection."
+maintainer: "Jane Street developers"
+authors: "Jane Street Group, LLC"
+license: "MIT"
+homepage: "https://github.com/janestreet/ppx_globalize"
+doc:
+  "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_globalize/index.html"
+bug-reports: "https://github.com/janestreet/ppx_globalize/issues"
+depends: [
+  "ocaml" {>= "5.1.0"}
+  "base"
+  "ppxlib_jane"
+  "dune" {>= "3.11.0"}
+  "ppxlib" {>= "0.33.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/janestreet/ppx_globalize.git"
+url {
+  src:
+    "https://github.com/patricoferris/ppx_globalize/archive/heads/5.2-ast-bump.tar.gz"
+  checksum: [
+    "md5=00f354eba0e6396fc27bf0897e339ee1"
+    "sha512=e4d65aa72329c242ab883a9a7e7c597cdd82c2f746cb86e9efee7b418431001c2312bf5bf1c82a05790b5998bd42c92eb0e5ab253217d01c105284c2ebf145f9"
+  ]
+}


### PR DESCRIPTION
### `ppx_globalize.v0.17.0`
A ppx rewriter that generates functions to copy local values to the global heap
Part of the Jane Street's PPX rewriters collection.



---
* Homepage: https://github.com/janestreet/ppx_globalize
* Source repo: git+https://github.com/janestreet/ppx_globalize.git
* Bug tracker: https://github.com/janestreet/ppx_globalize/issues

---
:camel: Pull-request generated by opam-publish v2.4.0