### PR TITLE
Package ppx_let.v0.17.0

### DIFF
--- a/packages/ppx_let/ppx_let.v0.17.0/opam
+++ b/packages/ppx_let/ppx_let.v0.17.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "Monadic let-bindings"
+description: "Part of the Jane Street's PPX rewriters collection."
+maintainer: "Jane Street developers"
+authors: "Jane Street Group, LLC"
+license: "MIT"
+homepage: "https://github.com/janestreet/ppx_let"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_let/index.html"
+bug-reports: "https://github.com/janestreet/ppx_let/issues"
+depends: [
+  "ocaml" {>= "5.1.0"}
+  "base"
+  "ppx_here"
+  "ppxlib_jane"
+  "dune" {>= "3.11.0"}
+  "ppxlib" {>= "0.33.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/janestreet/ppx_let.git"
+url {
+  src:
+    "https://github.com/patricoferris/ppx_let/archive/heads/5.2-ast-bump.tar.gz"
+  checksum: [
+    "md5=8f05502209583fb3fb61811a14ba50cc"
+    "sha512=f12a5cb30caa974579cb2ebf6a4b3ff4d75e1f762fede058cb50720f13a3f6253375058a51b1322fe8413d0cf724da65169b46c5f269123545c3b2bab33ca6d2"
+  ]
+}


### PR DESCRIPTION
### `ppx_let.v0.17.0`
Monadic let-bindings
Part of the Jane Street's PPX rewriters collection.



---
* Homepage: https://github.com/janestreet/ppx_let
* Source repo: git+https://github.com/janestreet/ppx_let.git
* Bug tracker: https://github.com/janestreet/ppx_let/issues

---
:camel: Pull-request generated by opam-publish v2.4.0