### PR TITLE
Package ppx_tydi.v0.17.0

### DIFF
--- a/packages/ppx_tydi/ppx_tydi.v0.17.0/opam
+++ b/packages/ppx_tydi/ppx_tydi.v0.17.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "Let expressions, inferring pattern type from expression."
+description:
+  "Provides a ppx for [let%tydi]: type-directed [let] bindings. In [let%tydi a = b in ...], [a]'s type is inferred from [b] rather than the other way around. This is convenient for record patterns whose fields are not in scope."
+maintainer: "Jane Street developers"
+authors: "Jane Street Group, LLC"
+license: "MIT"
+homepage: "https://github.com/janestreet/ppx_tydi"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_tydi/index.html"
+bug-reports: "https://github.com/janestreet/ppx_tydi/issues"
+depends: [
+  "ocaml" {>= "5.1.0"}
+  "base"
+  "dune" {>= "3.11.0"}
+  "ppxlib" {>= "0.33.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/janestreet/ppx_tydi.git"
+url {
+  src:
+    "https://github.com/patricoferris/ppx_tydi/archive/heads/5.2-ast-bump.tar.gz"
+  checksum: [
+    "md5=f7e5646eebc9cc50d4912ec8fd9a07e5"
+    "sha512=0cede8d961980a3e0447ee6017ac0b1b5594fdd49c0c715346b1e58514ffa61b95065ba188ccecbb84f2dfb2017c7ff102728a67ed217511f0fb7e60a021a80a"
+  ]
+}


### PR DESCRIPTION
### `ppx_tydi.v0.17.0`
Let expressions, inferring pattern type from expression.
Provides a ppx for [let%tydi]: type-directed [let] bindings. In [let%tydi a = b in ...], [a]'s type is inferred from [b] rather than the other way around. This is convenient for record patterns whose fields are not in scope.



---
* Homepage: https://github.com/janestreet/ppx_tydi
* Source repo: git+https://github.com/janestreet/ppx_tydi.git
* Bug tracker: https://github.com/janestreet/ppx_tydi/issues

---
:camel: Pull-request generated by opam-publish v2.4.0