### PR TITLE
Package ppx_inline_test.v0.17.0

### DIFF
--- a/packages/ppx_inline_test/ppx_inline_test.v0.17.0/opam
+++ b/packages/ppx_inline_test/ppx_inline_test.v0.17.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "Syntax extension for writing in-line tests in ocaml code"
+description: "Part of the Jane Street's PPX rewriters collection."
+maintainer: "Jane Street developers"
+authors: "Jane Street Group, LLC"
+license: "MIT"
+homepage: "https://github.com/janestreet/ppx_inline_test"
+doc:
+  "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_inline_test/index.html"
+bug-reports: "https://github.com/janestreet/ppx_inline_test/issues"
+depends: [
+  "ocaml" {>= "5.1.0"}
+  "base"
+  "sexplib0"
+  "time_now"
+  "dune" {>= "3.11.0"}
+  "ppxlib" {>= "0.33.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/janestreet/ppx_inline_test.git"
+url {
+  src:
+    "https://github.com/patricoferris/ppx_inline_test/archive/heads/5.2-ast-bump.tar.gz"
+  checksum: [
+    "md5=308ab202fae41742633fc317639dde14"
+    "sha512=52d8561424d45b63fe1ffe42eb7786d9d0c3ebbe0e7a735de43b2ce83bbd9b8dcd3f24ec81e0d0930c5223b1ed5500a75767a467bbf8c01c7de73acc2d2ad03c"
+  ]
+}


### PR DESCRIPTION
### `ppx_inline_test.v0.17.0`
Syntax extension for writing in-line tests in ocaml code
Part of the Jane Street's PPX rewriters collection.



---
* Homepage: https://github.com/janestreet/ppx_inline_test
* Source repo: git+https://github.com/janestreet/ppx_inline_test.git
* Bug tracker: https://github.com/janestreet/ppx_inline_test/issues

---
:camel: Pull-request generated by opam-publish v2.4.0