### PR TITLE
Package ppx_bench.v0.17.0

### DIFF
--- a/packages/ppx_bench/ppx_bench.v0.17.0/opam
+++ b/packages/ppx_bench/ppx_bench.v0.17.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "Syntax extension for writing in-line benchmarks in ocaml code"
+description: "Part of the Jane Street's PPX rewriters collection."
+maintainer: "Jane Street developers"
+authors: "Jane Street Group, LLC"
+license: "MIT"
+homepage: "https://github.com/janestreet/ppx_bench"
+doc:
+  "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_bench/index.html"
+bug-reports: "https://github.com/janestreet/ppx_bench/issues"
+depends: [
+  "ocaml" {>= "5.1.0"}
+  "ppx_inline_test"
+  "dune" {>= "3.11.0"}
+  "ppxlib" {>= "0.33.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/janestreet/ppx_bench.git"
+url {
+  src:
+    "https://github.com/patricoferris/ppx_bench/archive/heads/5.2-ast-bump.tar.gz"
+  checksum: [
+    "md5=70a985673376fec0ad23bf0975e813a9"
+    "sha512=417847a937f0395e8f35e95865137beabf8e1ba968a46cfd7fa0b285b068d67e888328272c4457309eb262c55a6a5ae6076e1160ee5e07e118fbf39b1c315a61"
+  ]
+}


### PR DESCRIPTION
### `ppx_bench.v0.17.0`
Syntax extension for writing in-line benchmarks in ocaml code
Part of the Jane Street's PPX rewriters collection.



---
* Homepage: https://github.com/janestreet/ppx_bench
* Source repo: git+https://github.com/janestreet/ppx_bench.git
* Bug tracker: https://github.com/janestreet/ppx_bench/issues

---
:camel: Pull-request generated by opam-publish v2.4.0