### PR TITLE
Package base_quickcheck.v0.17.0

### DIFF
--- a/packages/base_quickcheck/base_quickcheck.v0.17.0/opam
+++ b/packages/base_quickcheck/base_quickcheck.v0.17.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis:
+  "Randomized testing framework, designed for compatibility with Base"
+description: """\
+Base_quickcheck provides randomized testing in the style of Haskell's Quickcheck library,
+with support for built-in types as well as types provided by Base."""
+maintainer: "Jane Street developers"
+authors: "Jane Street Group, LLC"
+license: "MIT"
+homepage: "https://github.com/janestreet/base_quickcheck"
+doc:
+  "https://ocaml.janestreet.com/ocaml-core/latest/doc/base_quickcheck/index.html"
+bug-reports: "https://github.com/janestreet/base_quickcheck/issues"
+depends: [
+  "ocaml" {>= "5.1.0"}
+  "base"
+  "ppx_base"
+  "ppx_fields_conv"
+  "ppx_let"
+  "ppx_sexp_message"
+  "ppx_sexp_value"
+  "ppxlib_jane"
+  "splittable_random"
+  "dune" {>= "3.11.0"}
+  "ocaml-compiler-libs" {>= "v0.11.0"}
+  "ppxlib" {>= "0.33.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/janestreet/base_quickcheck.git"
+url {
+  src:
+    "https://github.com/patricoferris/base_quickcheck/archive/heads/5.2-ast-bump.tar.gz"
+  checksum: [
+    "md5=38be19b659aae46215cf4e1e0842ef73"
+    "sha512=c6eca40b38f8ac59973d3e7689a9ea58262aedfa0a085cbabaa965afc83c83f540923c892fb536d8e0f8893592a86d2c72964c67c3def4f08b36621e1018a12d"
+  ]
+}


### PR DESCRIPTION
### `base_quickcheck.v0.17.0`
Randomized testing framework, designed for compatibility with Base
Base_quickcheck provides randomized testing in the style of Haskell's Quickcheck library,
with support for built-in types as well as types provided by Base.



---
* Homepage: https://github.com/janestreet/base_quickcheck
* Source repo: git+https://github.com/janestreet/base_quickcheck.git
* Bug tracker: https://github.com/janestreet/base_quickcheck/issues

---
:camel: Pull-request generated by opam-publish v2.4.0