### PR TITLE
6 packages from patricoferris/ocaml-rpc at 9.0.1

### DIFF
--- a/packages/ppx_deriving_rpc/ppx_deriving_rpc.9.0.1/opam
+++ b/packages/ppx_deriving_rpc/ppx_deriving_rpc.9.0.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Ppx deriver for ocaml-rpc, a library to deal with RPCs in OCaml"
+description: """\
+`ocaml-rpc` is a library that provides remote procedure calls (RPC)
+using XML or JSON as transport encodings, and multiple generators
+for documentations, clients, servers, javascript bindings, python
+bindings, ...
+
+The transport mechanism itself is outside the scope of this library
+as all conversions are from and to strings."""
+maintainer: "Marcello Seri"
+authors: ["Thomas Gazagnaire" "Jon Ludlam"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-rpc"
+doc: "https://mirage.github.io/ocaml-rpc/ppx_deriving_rpc"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.0.0"}
+  "rpclib" {= version}
+  "rresult" {>= "0.3.0"}
+  "ppxlib" {>= "0.18.0"}
+  "lwt" {with-test & >= "3.0.0"}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+url {
+  src:
+    "https://github.com/patricoferris/ocaml-rpc/archive/heads/5.2-ast-bump.tar.gz"
+  checksum: [
+    "md5=5b1521ca8eb39add9b8a3a094885a879"
+    "sha512=409ebda0b3a64291bc09b0700aa87a88974d4d38d1483e1d94a15fd19403530292e526dfd5b33b3fbe2112958ea0dec3db2fd1fc913c2147bc6bf43430f1cf8d"
+  ]
+}

--- a/packages/rpclib-async/rpclib-async.9.0.1/opam
+++ b/packages/rpclib-async/rpclib-async.9.0.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "A library to deal with RPCs in OCaml - Async interface"
+description: """\
+`ocaml-rpc` is a library that provides remote procedure calls (RPC)
+using XML or JSON as transport encodings, and multiple generators
+for documentations, clients, servers, javascript bindings, python
+bindings, ...
+
+The transport mechanism itself is outside the scope of this library
+as all conversions are from and to strings."""
+maintainer: "Marcello Seri"
+authors: ["Thomas Gazagnaire" "Jon Ludlam"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-rpc"
+doc: "https://mirage.github.io/ocaml-rpc/rpclib-async"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+depends: [
+  "ocaml"
+  "alcotest" {with-test}
+  "dune" {>= "2.0.0"}
+  "rpclib" {= version}
+  "async" {>= "v0.9.0"}
+  "ppx_deriving_rpc" {with-test & = version}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+url {
+  src:
+    "https://github.com/patricoferris/ocaml-rpc/archive/heads/5.2-ast-bump.tar.gz"
+  checksum: [
+    "md5=5b1521ca8eb39add9b8a3a094885a879"
+    "sha512=409ebda0b3a64291bc09b0700aa87a88974d4d38d1483e1d94a15fd19403530292e526dfd5b33b3fbe2112958ea0dec3db2fd1fc913c2147bc6bf43430f1cf8d"
+  ]
+}

--- a/packages/rpclib-html/rpclib-html.9.0.1/opam
+++ b/packages/rpclib-html/rpclib-html.9.0.1/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis:
+  "A library to deal with RPCs in OCaml - html documentation generator"
+description: """\
+`ocaml-rpc` is a library that provides remote procedure calls (RPC)
+using XML or JSON as transport encodings, and multiple generators
+for documentations, clients, servers, javascript bindings, python
+bindings, ...
+
+The transport mechanism itself is outside the scope of this library
+as all conversions are from and to strings."""
+maintainer: "Marcello Seri"
+authors: ["Thomas Gazagnaire" "Jon Ludlam"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-rpc"
+doc: "https://mirage.github.io/ocaml-rpc/rpclib-html"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+depends: [
+  "ocaml"
+  "dune" {>= "2.0.0"}
+  "rpclib" {= version}
+  "cow" {>= "2.0.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+url {
+  src:
+    "https://github.com/patricoferris/ocaml-rpc/archive/heads/5.2-ast-bump.tar.gz"
+  checksum: [
+    "md5=5b1521ca8eb39add9b8a3a094885a879"
+    "sha512=409ebda0b3a64291bc09b0700aa87a88974d4d38d1483e1d94a15fd19403530292e526dfd5b33b3fbe2112958ea0dec3db2fd1fc913c2147bc6bf43430f1cf8d"
+  ]
+}

--- a/packages/rpclib-js/rpclib-js.9.0.1/opam
+++ b/packages/rpclib-js/rpclib-js.9.0.1/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "A library to deal with RPCs in OCaml - Bindings for js_of_ocaml"
+description: """\
+`ocaml-rpc` is a library that provides remote procedure calls (RPC)
+using XML or JSON as transport encodings, and multiple generators
+for documentations, clients, servers, javascript bindings, python
+bindings, ...
+
+The transport mechanism itself is outside the scope of this library
+as all conversions are from and to strings."""
+maintainer: "Marcello Seri"
+authors: ["Thomas Gazagnaire" "Jon Ludlam"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-rpc"
+doc: "https://mirage.github.io/ocaml-rpc/rpclib-js"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+depends: [
+  "ocaml"
+  "dune" {>= "2.0.0"}
+  "rpclib" {= version}
+  "js_of_ocaml" {>= "3.5.0"}
+  "js_of_ocaml-ppx" {>= "3.5.0"}
+  "lwt"
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+url {
+  src:
+    "https://github.com/patricoferris/ocaml-rpc/archive/heads/5.2-ast-bump.tar.gz"
+  checksum: [
+    "md5=5b1521ca8eb39add9b8a3a094885a879"
+    "sha512=409ebda0b3a64291bc09b0700aa87a88974d4d38d1483e1d94a15fd19403530292e526dfd5b33b3fbe2112958ea0dec3db2fd1fc913c2147bc6bf43430f1cf8d"
+  ]
+}

--- a/packages/rpclib-lwt/rpclib-lwt.9.0.1/opam
+++ b/packages/rpclib-lwt/rpclib-lwt.9.0.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "A library to deal with RPCs in OCaml - Lwt interface"
+description: """\
+`ocaml-rpc` is a library that provides remote procedure calls (RPC)
+using XML or JSON as transport encodings, and multiple generators
+for documentations, clients, servers, javascript bindings, python
+bindings, ...
+
+The transport mechanism itself is outside the scope of this library
+as all conversions are from and to strings."""
+maintainer: "Marcello Seri"
+authors: ["Thomas Gazagnaire" "Jon Ludlam"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-rpc"
+doc: "https://mirage.github.io/ocaml-rpc/rpclib-lwt"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+depends: [
+  "ocaml"
+  "alcotest" {with-test}
+  "dune" {>= "2.0.0"}
+  "rpclib" {= version}
+  "lwt" {>= "3.0.0"}
+  "alcotest-lwt" {with-test}
+  "ppx_deriving_rpc" {with-test & = version}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+url {
+  src:
+    "https://github.com/patricoferris/ocaml-rpc/archive/heads/5.2-ast-bump.tar.gz"
+  checksum: [
+    "md5=5b1521ca8eb39add9b8a3a094885a879"
+    "sha512=409ebda0b3a64291bc09b0700aa87a88974d4d38d1483e1d94a15fd19403530292e526dfd5b33b3fbe2112958ea0dec3db2fd1fc913c2147bc6bf43430f1cf8d"
+  ]
+}

--- a/packages/rpclib/rpclib.9.0.1/opam
+++ b/packages/rpclib/rpclib.9.0.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "A library to deal with RPCs in OCaml"
+description: """\
+`ocaml-rpc` is a library that provides remote procedure calls (RPC)
+using XML or JSON as transport encodings, and multiple generators
+for documentations, clients, servers, javascript bindings, python
+bindings, ...
+
+The transport mechanism itself is outside the scope of this library
+as all conversions are from and to strings."""
+maintainer: "Marcello Seri"
+authors: ["Thomas Gazagnaire" "Jon Ludlam"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-rpc"
+doc: "https://mirage.github.io/ocaml-rpc/rpclib"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "alcotest" {with-test}
+  "dune" {>= "2.0.0"}
+  "base64" {>= "3.4.0"}
+  "cmdliner" {>= "1.1.0"}
+  "rresult" {>= "0.3.0"}
+  "result" {>= "1.5"}
+  "xmlm"
+  "yojson" {>= "1.7.0"}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+url {
+  src:
+    "https://github.com/patricoferris/ocaml-rpc/archive/heads/5.2-ast-bump.tar.gz"
+  checksum: [
+    "md5=5b1521ca8eb39add9b8a3a094885a879"
+    "sha512=409ebda0b3a64291bc09b0700aa87a88974d4d38d1483e1d94a15fd19403530292e526dfd5b33b3fbe2112958ea0dec3db2fd1fc913c2147bc6bf43430f1cf8d"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `ppx_deriving_rpc.9.0.1`: Ppx deriver for ocaml-rpc, a library to deal with RPCs in OCaml
- `rpclib.9.0.1`: A library to deal with RPCs in OCaml
- `rpclib-async.9.0.1`: A library to deal with RPCs in OCaml - Async interface
- `rpclib-html.9.0.1`: A library to deal with RPCs in OCaml - html documentation generator
- `rpclib-js.9.0.1`: A library to deal with RPCs in OCaml - Bindings for js_of_ocaml
- `rpclib-lwt.9.0.1`: A library to deal with RPCs in OCaml - Lwt interface



---
* Homepage: https://github.com/mirage/ocaml-rpc
* Source repo: git://github.com/mirage/ocaml-rpc
* Bug tracker: https://github.com/mirage/ocaml-rpc/issues

---
:camel: Pull-request generated by opam-publish v2.4.0