### PR TITLE
Package ppx_deriving.6.0.4

### DIFF
--- a/packages/ppx_deriving/ppx_deriving.6.0.4/opam
+++ b/packages/ppx_deriving/ppx_deriving.6.0.4/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Type-driven code generation for OCaml"
+description: """\
+ppx_deriving provides common infrastructure for generating
+code based on type definitions, and a set of useful plugins
+for common tasks."""
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: "whitequark <whitequark@whitequark.org>"
+license: "MIT"
+tags: "syntax"
+homepage: "https://github.com/ocaml-ppx/ppx_deriving"
+doc: "https://ocaml-ppx.github.io/ppx_deriving/"
+bug-reports: "https://github.com/ocaml-ppx/ppx_deriving/issues"
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "1.6.3"}
+  "cppo" {>= "1.1.0" & build}
+  "ocamlfind"
+  "ppx_derivers"
+  "ppxlib" {>= "0.32.0"}
+  "ounit2" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ppx_deriving.git"
+url {
+  src:
+    "https://github.com/patricoferris/ppx_deriving/archive/heads/5.2-ast-bump.tar.gz"
+  checksum: [
+    "md5=345117dc5292757ccd6b944ba4fc8512"
+    "sha512=641a1fc2f9da3c242efda26fe909da463356d59397ec101cf30c4c1485c133d793c82bb9841a0e66beb86774aea18ca14f88f6e5ca88bba75df567a251b5aeef"
+  ]
+}


### PR DESCRIPTION
### `ppx_deriving.6.0.4`
Type-driven code generation for OCaml
ppx_deriving provides common infrastructure for generating
code based on type definitions, and a set of useful plugins
for common tasks.



---
* Homepage: https://github.com/ocaml-ppx/ppx_deriving
* Source repo: git+https://github.com/ocaml-ppx/ppx_deriving.git
* Bug tracker: https://github.com/ocaml-ppx/ppx_deriving/issues

---
:camel: Pull-request generated by opam-publish v2.4.0