### PR TITLE
7 packages from patricoferris/js_of_ocaml at 5.9.2

### DIFF
--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.5.9.2/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.5.9.2/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: "Ocsigen team <dev@ocsigen.org>"
+authors: "Ocsigen team <dev@ocsigen.org>"
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.15"}
+  "ocaml" {>= "4.08" & < "5.4"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "ppxlib" {>= "0.15.0"}
+  "re" {with-test}
+  "cmdliner" {>= "1.1.0"}
+  "sedlex" {>= "2.3"}
+  "qcheck" {with-test}
+  "menhir"
+  "menhirLib"
+  "menhirSdk"
+  "yojson"
+  "odoc" {with-doc}
+]
+depopts: ["ocamlfind"]
+conflicts: [
+  "ocamlfind" {< "1.5.1"}
+  "js_of_ocaml" {< "3.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs "@install" "@doc" {with-doc}]
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+url {
+  src:
+    "https://github.com/patricoferris/js_of_ocaml/archive/heads/5.2-ast-bump.tar.gz"
+  checksum: [
+    "md5=f229c8cfe5fb13402850c56d08aca4e8"
+    "sha512=f858150f8bfd93cd817d31ad14329b526d5e32c5d95c676d924b642ac1df9d04df5533c4934f7e1b2008a71aca5cd1b01886f9b27efda077cb7a2b2f9781bbca"
+  ]
+}

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.5.9.2/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.5.9.2/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: "Ocsigen team <dev@ocsigen.org>"
+authors: "Ocsigen team <dev@ocsigen.org>"
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.15"}
+  "ocaml" {>= "4.08"}
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
+  "lwt" {>= "2.4.4"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "ppxlib" {>= "0.22.0" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+depopts: ["graphics" "lwt_log"]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs "@install" "@doc" {with-doc}]
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+url {
+  src:
+    "https://github.com/patricoferris/js_of_ocaml/archive/heads/5.2-ast-bump.tar.gz"
+  checksum: [
+    "md5=f229c8cfe5fb13402850c56d08aca4e8"
+    "sha512=f858150f8bfd93cd817d31ad14329b526d5e32c5d95c676d924b642ac1df9d04df5533c4934f7e1b2008a71aca5cd1b01886f9b27efda077cb7a2b2f9781bbca"
+  ]
+}

--- a/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.5.9.2/opam
+++ b/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.5.9.2/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: "Ocsigen team <dev@ocsigen.org>"
+authors: "Ocsigen team <dev@ocsigen.org>"
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.15"}
+  "ocaml" {>= "4.08"}
+  "js_of_ocaml" {= version}
+  "ppxlib" {>= "0.15.0"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs "@install" "@doc" {with-doc}]
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+url {
+  src:
+    "https://github.com/patricoferris/js_of_ocaml/archive/heads/5.2-ast-bump.tar.gz"
+  checksum: [
+    "md5=f229c8cfe5fb13402850c56d08aca4e8"
+    "sha512=f858150f8bfd93cd817d31ad14329b526d5e32c5d95c676d924b642ac1df9d04df5533c4934f7e1b2008a71aca5cd1b01886f9b27efda077cb7a2b2f9781bbca"
+  ]
+}

--- a/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.5.9.2/opam
+++ b/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.5.9.2/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: "Ocsigen team <dev@ocsigen.org>"
+authors: "Ocsigen team <dev@ocsigen.org>"
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.15"}
+  "ocaml" {>= "4.08"}
+  "js_of_ocaml" {= version}
+  "ppxlib" {>= "0.15"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs "@install" "@doc" {with-doc}]
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+url {
+  src:
+    "https://github.com/patricoferris/js_of_ocaml/archive/heads/5.2-ast-bump.tar.gz"
+  checksum: [
+    "md5=f229c8cfe5fb13402850c56d08aca4e8"
+    "sha512=f858150f8bfd93cd817d31ad14329b526d5e32c5d95c676d924b642ac1df9d04df5533c4934f7e1b2008a71aca5cd1b01886f9b27efda077cb7a2b2f9781bbca"
+  ]
+}

--- a/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.5.9.2/opam
+++ b/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.5.9.2/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: "Ocsigen team <dev@ocsigen.org>"
+authors: "Ocsigen team <dev@ocsigen.org>"
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.15"}
+  "ocaml" {>= "4.08"}
+  "js_of_ocaml-compiler" {= version}
+  "ocamlfind" {>= "1.5.1"}
+  "cohttp-lwt-unix" {with-test}
+  "graphics" {with-test}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "ppxlib" {>= "0.15"}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs "@install" "@doc" {with-doc}]
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+url {
+  src:
+    "https://github.com/patricoferris/js_of_ocaml/archive/heads/5.2-ast-bump.tar.gz"
+  checksum: [
+    "md5=f229c8cfe5fb13402850c56d08aca4e8"
+    "sha512=f858150f8bfd93cd817d31ad14329b526d5e32c5d95c676d924b642ac1df9d04df5533c4934f7e1b2008a71aca5cd1b01886f9b27efda077cb7a2b2f9781bbca"
+  ]
+}

--- a/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.5.9.2/opam
+++ b/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.5.9.2/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: "Ocsigen team <dev@ocsigen.org>"
+authors: "Ocsigen team <dev@ocsigen.org>"
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.15"}
+  "ocaml" {>= "4.08"}
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
+  "react" {>= "1.2.2"}
+  "reactiveData" {>= "0.2"}
+  "tyxml" {>= "4.6"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "ppxlib" {>= "0.22.0" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs "@install" "@doc" {with-doc}]
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+url {
+  src:
+    "https://github.com/patricoferris/js_of_ocaml/archive/heads/5.2-ast-bump.tar.gz"
+  checksum: [
+    "md5=f229c8cfe5fb13402850c56d08aca4e8"
+    "sha512=f858150f8bfd93cd817d31ad14329b526d5e32c5d95c676d924b642ac1df9d04df5533c4934f7e1b2008a71aca5cd1b01886f9b27efda077cb7a2b2f9781bbca"
+  ]
+}

--- a/packages/js_of_ocaml/js_of_ocaml.5.9.2/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.5.9.2/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: "Ocsigen team <dev@ocsigen.org>"
+authors: "Ocsigen team <dev@ocsigen.org>"
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.15"}
+  "ocaml" {>= "4.08"}
+  "js_of_ocaml-compiler" {= version}
+  "ppxlib" {>= "0.15"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs "@install" "@doc" {with-doc}]
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+url {
+  src:
+    "https://github.com/patricoferris/js_of_ocaml/archive/heads/5.2-ast-bump.tar.gz"
+  checksum: [
+    "md5=f229c8cfe5fb13402850c56d08aca4e8"
+    "sha512=f858150f8bfd93cd817d31ad14329b526d5e32c5d95c676d924b642ac1df9d04df5533c4934f7e1b2008a71aca5cd1b01886f9b27efda077cb7a2b2f9781bbca"
+  ]
+}


### PR DESCRIPTION
Compiler from OCaml bytecode to JavaScript

This pull-request concerns:
- `js_of_ocaml.5.9.2`
- `js_of_ocaml-compiler.5.9.2`
- `js_of_ocaml-lwt.5.9.2`
- `js_of_ocaml-ppx.5.9.2`
- `js_of_ocaml-ppx_deriving_json.5.9.2`
- `js_of_ocaml-toplevel.5.9.2`
- `js_of_ocaml-tyxml.5.9.2`



---
* Homepage: https://ocsigen.org/js_of_ocaml/latest/manual/overview
* Source repo: git+https://github.com/ocsigen/js_of_ocaml.git
* Bug tracker: https://github.com/ocsigen/js_of_ocaml/issues

---
:camel: Pull-request generated by opam-publish v2.4.0