### PR TITLE
Package ppx_distr_guards.0.4

### DIFF
--- a/packages/ppx_distr_guards/ppx_distr_guards.0.4/opam
+++ b/packages/ppx_distr_guards/ppx_distr_guards.0.4/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Extension to distribute guards over or-patterns"
+description:
+  "`function%distr A x, _ | _, A x when p x -> e` will result in `function A x, _ when p x -> e | _, A x when p x -> e`"
+maintainer: "Ralf Vogler <ralf.vogler@gmail.com>"
+authors: "Ralf Vogler <ralf.vogler@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/vogler/ppx_distr_guards"
+doc: "https://vogler.github.io/ppx_distr_guards"
+bug-reports: "https://github.com/vogler/ppx_distr_guards/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ppxlib" {>= "0.15.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/vogler/ppx_distr_guards.git"
+url {
+  src:
+    "https://github.com/patricoferris/ppx_distr_guards/archive/heads/5.2-ast-bump.tar.gz"
+  checksum: [
+    "md5=a49d41f5560c4afe15e7f9a48913e59b"
+    "sha512=11a5d03069aa7cae82b6be87dccc95a787ecc2ab06d6f86a29cc89cfa06c66b06be47a90c6a41ff162fd1305bfbb5a4722ffec871d05c5d587acb3407a84acfe"
+  ]
+}


### PR DESCRIPTION
### `ppx_distr_guards.0.4`
Extension to distribute guards over or-patterns
`function%distr A x, _ | _, A x when p x -> e` will result in `function A x, _ when p x -> e | _, A x when p x -> e`



---
* Homepage: https://github.com/vogler/ppx_distr_guards
* Source repo: git+https://github.com/vogler/ppx_distr_guards.git
* Bug tracker: https://github.com/vogler/ppx_distr_guards/issues

---
:camel: Pull-request generated by opam-publish v2.4.0